### PR TITLE
Allow container to be run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM kkarczmarczyk/node-yarn
 
 # FROM registry.docker-cn.com/kkarczmarczyk/node-yarn
 
-ENV WORKSPACE=/root/workspace
+EXPOSE 3006
+
+ENV WORKSPACE=/opt/workspace
 
 RUN mkdir -p $WORKSPACE
 
@@ -20,4 +22,4 @@ RUN yarn
 
 ADD . $WORKSPACE
 
-CMD yarn prod
+CMD yarn docker

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "clean": "rimraf build",
     "build": "npm run clean && cross-env NODE_ENV=production webpack --colors --progress --config ./config/webpack.prod.config.js",
-    "prod": "npm run clean && cross-env NODE_ENV=production PORT=3006 node ./src/production",
+    "prod": "npm run clean && npm run docker",
+    "docker": "cross-env NODE_ENV=production PORT=3006 node ./src/production",
     "dev": "cross-env NODE_ENV=development PORT=3006 node ./src/development",
     "lint": "./node_modules/.bin/eslint src",
     "test": "./node_modules/.bin/jest --config jest.config.js --no-cache",


### PR DESCRIPTION
Make changes to the Dockerfile and package scripts to make image
amenable to running as non-root and with a read-only root file
system, both security best practices.

Move workspace out from under root home directory so it is accessible
to non-root users.  Provide package script for Docker container that
does not remove the build directory since this is not present in the
Docker container and trying to remove it fails for non-root users.

Also add EXPOSE command to Dockerfile to help people figure out what
port this app listens on.